### PR TITLE
Better Regex for key matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "get-users-dev": "node -r dotenv/config ./dest/getUsers.js users",
     "watch": "tsc -p ./ --watch"
   },
-  "version": "2.0.1"
+  "version": "2.0.2"
 }


### PR DESCRIPTION
Allows for space or underscore as well as dash when matching keys in branch or title, and forces keys to be uppercase so the unique set is case insensitive.